### PR TITLE
Float support

### DIFF
--- a/analyticscloud/importers/db.py
+++ b/analyticscloud/importers/db.py
@@ -19,12 +19,11 @@ SQL_TEXT_TYPES = (
 
 SQL_NUMERIC_TYPES = (
     sqltypes.BIGINT, sqltypes.DECIMAL, sqltypes.FLOAT,
-    sqltypes.INT, sqltypes.INTEGER, sqltypes.NUMERIC, sqltypes.Numeric,
+    sqltypes.INT, sqltypes.INTEGER, sqltypes.NUMERIC,
     sqltypes.REAL, sqltypes.SMALLINT
 )
 
-SQL_FLOAT_TYPES = (sqltypes.NUMERIC, sqltypes.Numeric, sqltypes.DECIMAL,
-                  sqltypes.FLOAT,)
+SQL_FLOAT_TYPES = (sqltypes.NUMERIC, sqltypes.DECIMAL, sqltypes.FLOAT,)
 
 SQL_DATE_TYPES = (sqltypes.DATETIME, sqltypes.TIMESTAMP, sqltypes.DATE)
 

--- a/analyticscloud/importers/db.py
+++ b/analyticscloud/importers/db.py
@@ -23,6 +23,9 @@ SQL_NUMERIC_TYPES = (
     sqltypes.REAL, sqltypes.SMALLINT
 )
 
+SQL_FLOAT_TYPES = (sqltypes.NUMERIC, sqltypes.Numeric, sqltypes.DECIMAL,
+                  sqltypes.FLOAT,)
+
 SQL_DATE_TYPES = (sqltypes.DATETIME, sqltypes.TIMESTAMP, sqltypes.DATE)
 
 SQL_SUPPORTED_TYPES = SQL_NUMERIC_TYPES + SQL_DATE_TYPES
@@ -63,12 +66,18 @@ def metadata_for_dbtype(dbtype):
     base_type = get_base_sqlclass(dbtype.__class__)
 
     if base_type in SQL_NUMERIC_TYPES:
-        return {
+        meta = {
             'type': 'Numeric',
             'precision': 18,
             'scale': 0,
             'defaultValue': 0
         }
+        if base_type in SQL_FLOAT_TYPES:
+            if dbtype.precision is not None:
+                meta['precision'] = min([dbtype.precision, 18])
+            if dbtype.scale is not None:
+                meta['scale'] = min([dbtype.scale, meta['precision'] - 1])
+        return meta
 
     if base_type in SQL_DATE_TYPES:
         # Treat timezones differently?


### PR DESCRIPTION
This update should allow float types to specify precision and scale more explicitly. Precision must be <= 18, and scale must be less than precision.

It may be in a user's best interest to specify these values when they create tables. If its not specified, and the default values for precision and scale are used (18, 6) then values appear to get zero padded after the decimal (1.1 -> 1.100000).

When values are outside of the max scale/precision (for example a value like 123456123456123456123456.123456123456123456123456) the whole data set appears to get rounded/normalized in some unpredictable fashion, but the upload still goes through.